### PR TITLE
use method update_param instead of updating environment variable rack…

### DIFF
--- a/lib/omniauth/strategies/cas/logout_request.rb
+++ b/lib/omniauth/strategies/cas/logout_request.rb
@@ -40,16 +40,9 @@ module OmniAuth
         end
 
         def inject_params(new_params)
-          #params is only read once from env['rack.input'] so updating this environment variable has no use
-          #cf. https://github.com/rack/rack/blob/master/lib/rack/request.rb
           new_params.each do |k,v|
             @request.update_param(k,v)
           end
-        rescue
-          # A no-op intended to ensure that the ensure block is run
-          raise
-        ensure
-          @request.env['rack.input'].rewind
         end
 
         def single_sign_out_callback

--- a/lib/omniauth/strategies/cas/logout_request.rb
+++ b/lib/omniauth/strategies/cas/logout_request.rb
@@ -40,9 +40,11 @@ module OmniAuth
         end
 
         def inject_params(new_params)
-          rack_input = @request.env['rack.input'].read
-          params = Rack::Utils.parse_query(rack_input, '&').merge new_params
-          @request.env['rack.input'] = StringIO.new(Rack::Utils.build_query(params))
+          #params is only read once from env['rack.input'] so updating this environment variable has no use
+          #cf. https://github.com/rack/rack/blob/master/lib/rack/request.rb
+          new_params.each do |k,v|
+            @request.update_param(k,v)
+          end
         rescue
           # A no-op intended to ensure that the ensure block is run
           raise


### PR DESCRIPTION
Apparently changing request.env["rack.input"] does not change anything
to the hash request.params, for this is only read once from its input:

cf. https://github.com/rack/rack/blob/master/lib/rack/request.rb: 263